### PR TITLE
Fix for event routing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject venue "0.1.3"
+(defproject venue "0.1.4-SNAPSHOT"
   :description "Experimental MVVM-like framework for ClojureScript"
   :url "https://github.com/mastodonc/venue"
   :license {:name "Eclipse Public License"

--- a/src/venue/core.cljs
+++ b/src/venue/core.cljs
@@ -59,6 +59,10 @@
        (reduce conj)
        id))
 
+(defn- fixtures-by-target
+  [target]
+  (->> @venue-state target :fixtures))
+
 (defn- route-list
   []
   (->> @venue-state
@@ -76,11 +80,6 @@
          (mapcat :fixtures)
          (map second)
          (filter #(or (and include-static? (:static %)) (= (:route %) location))))))
-
-(defn- get-current-fixture
-  [cursor]
-  (let [current-id (:current @cursor)]
-    (current-id (:fixtures cursor))))
 
 (defn- get-current-fixtures
   []
@@ -140,11 +139,11 @@
            ;; FIXME there's something in this go block that upsets the compiler:
            ;; "WARNING: Use of undeclared Var venue.core/bit__16711__auto__"
            (go-loop []
-             (let [e (<! event-chan)
-                   {:keys [view-model state]} (get-current-fixture cursor)
+             (let [{:keys [event args current-ids]} (<! event-chan)
+                   {:keys [view-model id]} (some (fixtures-by-target target) current-ids)
                    vm ((view-model))]
                (when (satisfies? IHandleEvent vm)
-                 (apply (partial handle-event vm) (conj e state))))
+                 (apply (partial handle-event vm) (conj [event args] (-> venue-cursor target :fixtures id :state)))))
              (recur)))
          om/IRender
          (render [_]
@@ -204,7 +203,8 @@
   (let [ktarget (keyword target)
         mfix (-> fix
                  (assoc :target ktarget)
-                 (assoc :static false))]
+                 (assoc :static false)
+                 (update :state #(merge % {:__v_id id})))]
     (swap! venue-state assoc-in [ktarget :fixtures id] mfix)))
 
 (defn- add-static-view!
@@ -212,7 +212,8 @@
   (let [ktarget (keyword target)]
     (swap! venue-state assoc-in [ktarget :fixtures id] (-> fixture
                                                            (assoc :target ktarget)
-                                                           (assoc :static true)))))
+                                                           (assoc :static true)
+                                                           (update :state #(merge % {:__v_id id}))))))
 
 (defn- start-service-loop!
   []
@@ -248,7 +249,9 @@
    (raise! owner event {}))
   ([owner event args]
    (let [c (om/get-shared owner [:event-chan])]
-     (put! c [event args]))))
+     (put! c {:event event :args args :current-ids (->> @venue-state
+                                                        (map val)
+                                                        (map :current))}))))
 
 (defn request!
   ([cursor service id]

--- a/src/venue/core.cljs
+++ b/src/venue/core.cljs
@@ -203,8 +203,7 @@
   (let [ktarget (keyword target)
         mfix (-> fix
                  (assoc :target ktarget)
-                 (assoc :static false)
-                 (update :state #(merge % {:__v_id id})))]
+                 (assoc :static false))]
     (swap! venue-state assoc-in [ktarget :fixtures id] mfix)))
 
 (defn- add-static-view!
@@ -212,8 +211,7 @@
   (let [ktarget (keyword target)]
     (swap! venue-state assoc-in [ktarget :fixtures id] (-> fixture
                                                            (assoc :target ktarget)
-                                                           (assoc :static true)
-                                                           (update :state #(merge % {:__v_id id}))))))
+                                                           (assoc :static true)))))
 
 (defn- start-service-loop!
   []


### PR DESCRIPTION
Some raised events were ending up at the wrong view-model when a switch
was imminent. There is now more protection that the event will find the
correct destination.