### PR TITLE
Fix timeouts using `alts!`

### DIFF
--- a/example/src/example/services/data.cljs
+++ b/example/src/example/services/data.cljs
@@ -1,6 +1,13 @@
 (ns example.services.data
-  (:require [venue.core :as venue])
-  (:require-macros [cljs-log.core :as log]))
+  (:require [venue.core :as venue]
+            [cljs.core.async :refer [chan close! put!]])
+  (:require-macros [cljs-log.core :as log]
+                   [cljs.core.async.macros :as m :refer [go]]))
+
+(defn timeout [ms]
+  (let [c (chan)]
+    (js/setTimeout (fn [] (close! c)) ms)
+    c))
 
 
 (defmulti request-handler
@@ -22,4 +29,9 @@
 (defmethod request-handler
   :login
   [owner _ args result-ch]
-  (log/debug "Got login request"))
+  (let [wait 6000]
+    (log/debug "Got login request. Waiting" wait "ms...")
+    (go
+      (<! (timeout wait))
+      (log/debug "Finished waiting.")
+      (put! result-ch [:success "OK"]))))

--- a/example/src/example/services/data.cljs
+++ b/example/src/example/services/data.cljs
@@ -1,14 +1,8 @@
 (ns example.services.data
   (:require [venue.core :as venue]
-            [cljs.core.async :refer [chan close! put!]])
+            [cljs.core.async :refer [chan close! put! timeout]])
   (:require-macros [cljs-log.core :as log]
                    [cljs.core.async.macros :as m :refer [go]]))
-
-(defn timeout [ms]
-  (let [c (chan)]
-    (js/setTimeout (fn [] (close! c)) ms)
-    c))
-
 
 (defmulti request-handler
   (fn [owner event args result-ch] event))

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject venue "0.1.6"
+(defproject venue "0.1.7-SNAPSHOT"
   :description "Experimental MVVM-like framework for ClojureScript"
   :url "https://github.com/mastodonc/venue"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Naively, the feature to avoid timeouts didn't work at all. This solution uses `alts!` rather than `alt!` which allows us to filter out nil channels - `alt!` does not easily facilitate this.