### PR TITLE
Adds IDeactivate and `deactivate` to view-models

### DIFF
--- a/example/src/example/home/view_model.cljs
+++ b/example/src/example/home/view_model.cljs
@@ -25,7 +25,12 @@
                        (response-handler owner [event outcome] response context))
     venue/IActivate
     (activate [owner args cursor]
-                (on-activate owner args cursor))
+      (on-activate owner args cursor))
+
+    venue/IDeactivate
+    (deactivate [owner cursor]
+      (log/info "Deactivating home"))
+
     venue/IInitialise
     (initialise [owner cursor]
       (on-initialise owner cursor))))

--- a/example/src/example/submit/view_model.cljs
+++ b/example/src/example/submit/view_model.cljs
@@ -6,7 +6,7 @@
 
 (defn handler
   [event args cursor ctx]
-  (println "Got event" event))
+  (log/debug "Got event" event))
 
 (defn view-model
   [ctx]


### PR DESCRIPTION
Gives view-models the ability to call 'deactivate' when they are no longer the current view-model for a given target. Ideal for cleaning up recurring tasks, ahem.